### PR TITLE
light-16: update attachment text color

### DIFF
--- a/mutt-colors-solarized-light-16.muttrc
+++ b/mutt-colors-solarized-light-16.muttrc
@@ -29,7 +29,7 @@ color error         red             default
 color tilde         white           default         
 color message       cyan            default         
 color markers       red             black           
-color attachment    black           default         
+color attachment    cyan            default         
 color search        brightmagenta   default         
 #color status        J_black         J_status        
 color status        brightblue      white           


### PR DESCRIPTION
The definition of 'black' ended up making the attachment text nearly
illegible on a stock xterm which includes 256-color support but using the
solarized light-16 configuration for mutt.  Changing 'black' to 'cyan'
makes it much clearer without overwhelming the actual text.

Signed-off-by: Joe MacDonald joe_macdonald@mentor.com
