### PR TITLE
README: fix block syntax according to the four-space rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ visit the [github repository for Solarized][solarized-github].
 Installation
 ------------
 
-1. Move the mutt-colors-solarized directory into the same location as your 
-   muttrc. Alternately, you can copy just the version of the colorscheme you 
-   will be using (see below for details).
+1.  Move the mutt-colors-solarized directory into the same location as your
+    muttrc. Alternately, you can copy just the version of the colorscheme you
+    will be using (see below for details).
 
-2. Source the colorscheme in your muttrc. Only one of the following, depending 
-   on the light or dark background you wish to use, and whether you want to use 
-   the native 16 colors of your terminal emulator or the approximatation 
-   provided by the 256 color values. See note below for recommendations.
+2.  Source the colorscheme in your muttrc. Only one of the following, depending
+    on the light or dark background you wish to use, and whether you want to use
+    the native 16 colors of your terminal emulator or the approximatation
+    provided by the 256 color values. See note below for recommendations.
 
-    source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-dark-16.muttrc
-    source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-light-16.muttrc
-    source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-dark-256.muttrc
-    source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-light-256.muttrc
+        source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-dark-16.muttrc
+        source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-light-16.muttrc
+        source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-dark-256.muttrc
+        source $MAILCONF/mutt-colors-solarized/mutt-colors-solarized-light-256.muttrc
 
 Note: You can safely ignore the compile colors script and the template file.  
 They are used only for creating the actual colorscheme files. If you want to 


### PR DESCRIPTION
It seems that GitHub interprets the indentation here different than
other Markdown parsers, which always count multiples of four spaces as
indentation. GitHub also accepts three spaces as indentation for the
list item. To be compatible with other Markdown implementations, apply
the four-space rule.

The code block here is inside a list block, so it must be indented by
four spaces more than the list block.